### PR TITLE
Change to Gorax dynamic spawn

### DIFF
--- a/MMOCoreORB/bin/scripts/mobile/spawn/endor_world.lua
+++ b/MMOCoreORB/bin/scripts/mobile/spawn/endor_world.lua
@@ -1597,10 +1597,10 @@ endor_world = {
 		{
 			lairTemplateName = "endor_gorax_neutral_none",
 			spawnLimit = 5,
-			minDifficulty = 131,
+			minDifficulty = 85,
 			maxDifficulty = 300,
 			numberToSpawn = 0,
-			weighting = 1,
+			weighting = 10,
 			size = 35
 		},
 		{


### PR DESCRIPTION
Increased weighting from 1 to 10 and reduced minimum difficulty to 85 to allow regular goraxes to spawn