### PR TITLE
Added: Thrawn to socialgroup

### DIFF
--- a/MMOCoreORB/bin/scripts/mobile/custom_content/isd/isd_thrawn.lua
+++ b/MMOCoreORB/bin/scripts/mobile/custom_content/isd/isd_thrawn.lua
@@ -1,7 +1,7 @@
 isd_thrawn = Creature:new {
 	--objectName = "",
 	customName = "\\#00ff00<<< General Thrawn >>> \\#ff0000[lvl 300]",
-	socialGroup = "",
+	socialGroup = "mercenary",
 	pvpFaction = "",
 	faction = "",
 	level = 300,


### PR DESCRIPTION
Added to mercenary socialgroup to avoid stormtroopers from kill or preventing players from killing and getting loot.