### PR TITLE
Created: Senator Rank (Name subject to change)

### DIFF
--- a/MMOCoreORB/bin/scripts/skills/staff/senator.lua
+++ b/MMOCoreORB/bin/scripts/skills/staff/senator.lua
@@ -1,0 +1,31 @@
+senator = {
+	skillName = "senator",
+	parentName = "",
+	graphType = 4,
+	godOnly = 0,
+	title = 1,
+	profession = 0,
+	hidden = 0,
+	moneyRequired = 0,
+	pointsRequired = 0,
+	skillsRequiredCount = 0,
+	skillsRequired = {},
+	preclusionSkills = {},
+	xpType = "",
+	xpCost = 0,
+	xpCap = 0,
+	missionsRequired = {},
+	apprenticeshipsRequired = 0,
+	statsRequired = {},
+	speciesRequired = {},
+	jediStateRequired = 0,
+	skillAbility = {},
+	commands = {
+	},
+	skillModifiers = {},
+	schematicsGranted = {},
+	schematicsRevoked = {},
+	searchable = 0
+}
+
+addSkill(senator)


### PR DESCRIPTION
This rank was created to be given to those on the server who have dedicated their time into helping new players, existing players, and over helping the server grow.
Notes: This is a visible rank in game, just like the EC, CSR, and Owner ranks. However this rank does not have any extra abilities. It is strictly for the visible title, so that others may know that this player has helped, and is continuing to help other players.