### PR TITLE
Adjusted: Dungeon Boss Loot

### DIFF
--- a/MMOCoreORB/bin/scripts/mobile/custom_content/dungeon/ig_88/ig_88_boss.lua
+++ b/MMOCoreORB/bin/scripts/mobile/custom_content/dungeon/ig_88/ig_88_boss.lua
@@ -30,9 +30,9 @@ ig_88_boss = Creature:new {
 	lootGroups = {
 		{
 			groups = {
-				{group = "clothing_attachments", chance = 10000000},
+				{group = "g_named_crystals", chance = 10000000},
 			},
-			lootChance = 10000000
+			lootChance = 5000000
 		},
 		{
 			groups = {
@@ -54,6 +54,96 @@ ig_88_boss = Creature:new {
 		},
 		{
 			groups = {
+				{group = "g_cloak_of_hate", chance = 10000000},
+			},
+			lootChance = 1500000
+		},
+		{
+			groups = {
+				{group = "capes", chance = 10000000},
+			},
+			lootChance = 1500000
+		},
+		{
+			groups = {
+				{group = "nge_all", chance = 10000000},
+			},
+			lootChance = 10000000
+		},
+		{
+			groups = {
+				{group = "goggles_all", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "neck_crafter", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "non_jedi_ring_crafter_second", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "non_jedi_ring_crafter", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "non_jedi_rings_ranged", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "non_jedi_rings", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "jedi_earings", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "jedi_bracelets", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "jedi_neck", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "jedi_rings", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "g_necklaces", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "clothing_attachments", chance = 10000000},
+			},
+			lootChance = 10000000
+		},
+		{
+			groups = {
 				{group = "armor_attachments", chance = 10000000},
 			},
 			lootChance = 10000000
@@ -66,12 +156,21 @@ ig_88_boss = Creature:new {
 		},
 		{
 			groups = {
-				{group = "tierone", chance = 1500000},
-				{group = "tiertwo", chance = 3500000},
-				{group = "tierthree", chance = 2500000},
-				{group = "tierdiamond", chance = 2500000},
+				{group = "worldbosscrate", chance = 10000000},
 			},
-			lootChance = 2000000
+			lootChance = 10000000
+		},
+		{
+			groups = {
+				{group = "vehicledeedsnormal", chance = 10000000},
+			},
+			lootChance = 5000000
+		},
+		{
+			groups = {
+				{group = "vehicledeedsrare", chance = 10000000},
+			},
+			lootChance = 2500000
 		},
 		{
 			groups = {
@@ -80,7 +179,16 @@ ig_88_boss = Creature:new {
 				{group = "tierthree", chance = 2500000},
 				{group = "tierdiamond", chance = 2500000},
 			},
-			lootChance = 2000000
+			lootChance = 10000000
+		},
+		{
+			groups = {
+				{group = "tierone", chance = 1500000},
+				{group = "tiertwo", chance = 3500000},
+				{group = "tierthree", chance = 2500000},
+				{group = "tierdiamond", chance = 2500000},
+			},
+			lootChance = 10000000
 		}
 	},
 	weapons = {"tusken_weapons"},

--- a/MMOCoreORB/bin/scripts/mobile/custom_content/dungeon/nightsister_temple/nightsisterqueenboss.lua
+++ b/MMOCoreORB/bin/scripts/mobile/custom_content/dungeon/nightsister_temple/nightsisterqueenboss.lua
@@ -30,9 +30,9 @@ nightsisterqueenboss = Creature:new {
 	lootGroups = {
 		{
 			groups = {
-				{group = "clothing_attachments", chance = 10000000},
+				{group = "g_named_crystals", chance = 10000000},
 			},
-			lootChance = 10000000
+			lootChance = 5000000
 		},
 		{
 			groups = {
@@ -54,6 +54,96 @@ nightsisterqueenboss = Creature:new {
 		},
 		{
 			groups = {
+				{group = "g_cloak_of_hate", chance = 10000000},
+			},
+			lootChance = 1500000
+		},
+		{
+			groups = {
+				{group = "capes", chance = 10000000},
+			},
+			lootChance = 1500000
+		},
+		{
+			groups = {
+				{group = "nge_all", chance = 10000000},
+			},
+			lootChance = 10000000
+		},
+		{
+			groups = {
+				{group = "goggles_all", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "neck_crafter", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "non_jedi_ring_crafter_second", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "non_jedi_ring_crafter", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "non_jedi_rings_ranged", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "non_jedi_rings", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "jedi_earings", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "jedi_bracelets", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "jedi_neck", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "jedi_rings", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "g_necklaces", chance = 10000000},
+			},
+			lootChance = 2000000
+		},
+		{
+			groups = {
+				{group = "clothing_attachments", chance = 10000000},
+			},
+			lootChance = 10000000
+		},
+		{
+			groups = {
 				{group = "armor_attachments", chance = 10000000},
 			},
 			lootChance = 10000000
@@ -66,12 +156,21 @@ nightsisterqueenboss = Creature:new {
 		},
 		{
 			groups = {
-				{group = "tierone", chance = 1500000},
-				{group = "tiertwo", chance = 3500000},
-				{group = "tierthree", chance = 2500000},
-				{group = "tierdiamond", chance = 2500000},
+				{group = "worldbosscrate", chance = 10000000},
 			},
-			lootChance = 2000000
+			lootChance = 10000000
+		},
+		{
+			groups = {
+				{group = "vehicledeedsnormal", chance = 10000000},
+			},
+			lootChance = 5000000
+		},
+		{
+			groups = {
+				{group = "vehicledeedsrare", chance = 10000000},
+			},
+			lootChance = 2500000
 		},
 		{
 			groups = {
@@ -80,7 +179,16 @@ nightsisterqueenboss = Creature:new {
 				{group = "tierthree", chance = 2500000},
 				{group = "tierdiamond", chance = 2500000},
 			},
-			lootChance = 2000000
+			lootChance = 10000000
+		},
+		{
+			groups = {
+				{group = "tierone", chance = 1500000},
+				{group = "tiertwo", chance = 3500000},
+				{group = "tierthree", chance = 2500000},
+				{group = "tierdiamond", chance = 2500000},
+			},
+			lootChance = 10000000
 		}
 	},
 	weapons = {"mixed_force_weapons"},


### PR DESCRIPTION
-Fixed the Night Sister and IG88 bosses loot tables. They now drop World Boss crates as all other bosses do.