### PR TITLE
[Manalore Patch] Disable boss spawn screenplays

### DIFF
--- a/Flurry/Stable Server/Core3/MMOCoreORB/bin/scripts/screenplays/custom_screenplays/mandalore/DarthCaedusCave.lua
+++ b/Flurry/Stable Server/Core3/MMOCoreORB/bin/scripts/screenplays/custom_screenplays/mandalore/DarthCaedusCave.lua
@@ -62,6 +62,6 @@ function DarthCaedusCave:spawnMobiles()
 	spawnMobile("mandalore", "darth_caedus_follower", 1800, -48.4, -87.2, -146.7, 80, 8566161)
 	spawnMobile("mandalore", "darth_caedus_follower", 1800, -76.3, -99.3, -156.4, 34, 8566159)
 	spawnMobile("mandalore", "darth_caedus_follower", 1800, -79.2, -100.6, -136.5, 116, 8566159)
---	spawnMobile("mandalore", "darth_caedus", 10800, -91.1, -100.7, -95.8, 170, 8566162)
+	spawnMobile("mandalore", "darth_caedus", 10800, -91.1, -100.7, -95.8, 170, 8566162)
 		
 end

--- a/Flurry/Stable Server/Core3/MMOCoreORB/bin/scripts/screenplays/custom_screenplays/mandalore/ShadowCollectiveCave.lua
+++ b/Flurry/Stable Server/Core3/MMOCoreORB/bin/scripts/screenplays/custom_screenplays/mandalore/ShadowCollectiveCave.lua
@@ -51,6 +51,6 @@ function ShadowCollectiveCave:spawnMobiles()
 	spawnMobile("mandalore", "shadow_collective_criminal", 1800, 154.2, -66.2, -123.7, -65, 8566288)
 	spawnMobile("mandalore", "shadow_collective_criminal", 1800, 142.9, -66.5, -88.3, -140, 8566288)
 	spawnMobile("mandalore", "shadow_collective_criminal", 1800, 164.1, -66.8, -97.5, -96, 8566289)
---	spawnMobile("mandalore", "shadow_collective_sc87", 10800, 190.1, -66.5, -102.8, -83, 8566289)
+	spawnMobile("mandalore", "shadow_collective_sc87", 10800, 190.1, -66.5, -102.8, -83, 8566289)
 		
 end

--- a/Flurry/Stable Server/Core3/MMOCoreORB/bin/scripts/screenplays/custom_screenplays/mandalore/TaungWarriorBunker.lua
+++ b/Flurry/Stable Server/Core3/MMOCoreORB/bin/scripts/screenplays/custom_screenplays/mandalore/TaungWarriorBunker.lua
@@ -155,8 +155,8 @@ function TaungWarriorBunker:spawnMobiles()
 	spawnMobile("mandalore", "taung_warrior", 1800, -54.1, -50.0, 0.1, -89, 8566235)
 	spawnMobile("mandalore", "taung_warrior", 1800, -41.8, -50.0, 5.0, -136, 8566237)
 	spawnMobile("mandalore", "taung_warrior", 1800, -41.3, -50.0, -4.1, -50, 8566237)
---	spawnMobile("mandalore", "dw_at", 300, -112.0, -50.0, 53.9, 87, 8566234)
+	spawnMobile("mandalore", "lom_pyke", 10800, -85.8, -50.0, 59.8, 0.7, 8565775}
 	spawnMobile("mandalore", "taung_warrior", 1800, -53.6, -50.0, 116.4, -86, 8566238)
---	spawnMobile("mandalore", "mandalore_the_resurrector", 10800, -22.8, -50.0, 0.4, -93, 8566237)
+	spawnMobile("mandalore", "mandalore_the_resurrector", 10800, -22.8, -50.0, 0.4, -93, 8566237)
 	
 end

--- a/Flurry/Stable Server/Core3/MMOCoreORB/bin/scripts/screenplays/custom_screenplays/mandalore/VizslaHideout.lua
+++ b/Flurry/Stable Server/Core3/MMOCoreORB/bin/scripts/screenplays/custom_screenplays/mandalore/VizslaHideout.lua
@@ -68,6 +68,6 @@ function VizslaHideout:spawnMobiles()
 	spawnMobile("mandalore", "vizsla_loyalist", 1800, -67.2, -96.2, -146.0, 91, 8566172)
 	spawnMobile("mandalore", "vizsla_loyalist", 1800, -77.6, -99.5, -159.1, -4, 8566172)
 	spawnMobile("mandalore", "vizsla_loyalist", 1800, -98.4, -102.0, -137.3, 97, 8566172)
---	spawnMobile("mandalore", "tor_vizsla", 10800, -90.7, -101.1, -102.6, -176, 8566175)
+	spawnMobile("mandalore", "tor_vizsla", 10800, -90.7, -101.1, -102.6, -176, 8566175)
 		
 end


### PR DESCRIPTION
Disabled until bug crashing server on respawn can be fixed. Bosses added back into POI screenplay as normal spawn event inside POI screenplay, shouldnt crash the server on respawn.