### PR TITLE
[RIP] NPC placed for Rizz

### DIFF
--- a/Flurry/Stable Server/Core3/MMOCoreORB/bin/scripts/mobile/ghost/rizz.lua
+++ b/Flurry/Stable Server/Core3/MMOCoreORB/bin/scripts/mobile/ghost/rizz.lua
@@ -1,0 +1,34 @@
+rizz_ghost = Creature:new {
+	customName = "Rizz (The Fallen)",
+	socialGroup = "townsperson",
+	pvpFaction = "",
+	faction = "",
+	level = 350,
+	chanceHit = 100.00,
+	damageMin = 100000,
+	damageMax = 100000,
+	baseXp = 278490,
+	baseHAM = 50000000,
+	baseHAMmax = 50000000,
+	armor = 3,
+	resists = {190,190,190,190,190,190,190,190,190},
+	meatType = "",
+	meatAmount = 0,
+	hideType = "",
+	hideAmount = 0,
+	boneType = "",
+	boneAmount = 0,
+	milk = 0,
+	tamingChance = 0,
+	ferocity = 0,
+	pvpBitmask = NONE,
+	creatureBitmask = NONE,
+	diet = HERBIVORE,
+
+	templates = {"object/mobile/ep3/palpatine_hologram.iff"},
+	lootGroups = {},	
+	weapons = {},
+	attacks = {}
+}
+
+CreatureTemplates:addCreatureTemplate(rizz_ghost, "rizz_ghost")

--- a/Flurry/Stable Server/Core3/MMOCoreORB/bin/scripts/mobile/ghost/serverobjects.lua
+++ b/Flurry/Stable Server/Core3/MMOCoreORB/bin/scripts/mobile/ghost/serverobjects.lua
@@ -1,2 +1,3 @@
 --Fallen Friends
 includeFile("ghost/geistvater.lua") -- Awakening, former CoA member
+includeFile("ghost/rizz.lua") -- Badland's Son

--- a/Flurry/Stable Server/Core3/MMOCoreORB/bin/scripts/screenplays/cities/corellia_coronet.lua
+++ b/Flurry/Stable Server/Core3/MMOCoreORB/bin/scripts/screenplays/cities/corellia_coronet.lua
@@ -464,4 +464,5 @@ function CorelliaCoronetScreenPlay:spawnMobiles()
   
   -- Fallen Players
   spawnMobile(self.planet, "geistvater_ghost", 0, -159, 28, -4723, 0, 0)
+  spawnMobile(self.planet, "rizz_ghost", 0, -159, 28, -4725.91, 0, 0)
 end


### PR DESCRIPTION
Rizz is another swg player that has recently passed. He was part of the flurry family.  We remember him, as a NPC has been placed in Coronet in front of the starport.