### PR TITLE
Fixes for Mandalore Deathwatch SBD

### DIFF
--- a/MMOCoreORB/bin/scripts/mobile/lair/creature_lair/mandalore_deathwatch_sbd_lair.lua
+++ b/MMOCoreORB/bin/scripts/mobile/lair/creature_lair/mandalore_deathwatch_sbd_lair.lua
@@ -1,4 +1,4 @@
-mandalore_deathwatch_sbd_lair_neutral = Lair:new {
+mandalore_deathwatch_sbd_lair = Lair:new {
 		mobiles = {{"deathwatch_sbd.lua",1}},
 		--bossMobiles = {{"deathwatch_sbd.lua",1}},
 		spawnLimit = 15,
@@ -9,4 +9,4 @@ mandalore_deathwatch_sbd_lair_neutral = Lair:new {
 	  	buildingsVeryHard = {"object/tangible/lair/base/poi_all_lair_rock_shelter_large_evil_fire_small.iff"},
 }
 
-addLairTemplate("mandalore_deathwatch_sbd_lair_neutral", mandalore_deathwatch_sbd_lair_neutral)
+addLairTemplate("mandalore_deathwatch_sbd_lair", mandalore_deathwatch_sbd_lair)

--- a/MMOCoreORB/bin/scripts/mobile/lair/creature_lair/mandalore_deathwatch_sbd_lair.lua
+++ b/MMOCoreORB/bin/scripts/mobile/lair/creature_lair/mandalore_deathwatch_sbd_lair.lua
@@ -1,6 +1,6 @@
 mandalore_deathwatch_sbd_lair = Lair:new {
-		mobiles = {{"deathwatch_sbd.lua",1}},
-		--bossMobiles = {{"deathwatch_sbd.lua",1}},
+		mobiles = {{"deathwatch_sbd",1}},
+		--bossMobiles = {{"deathwatch_sbd",1}},
 		spawnLimit = 15,
 		buildingsVeryEasy = {"object/tangible/lair/base/poi_all_lair_rock_shelter_large_evil_fire_small.iff"},
 	  	buildingsEasy = {"object/tangible/lair/base/poi_all_lair_rock_shelter_large_evil_fire_small.iff"},

--- a/MMOCoreORB/bin/scripts/mobile/lair/creature_lair/serverobjects.lua
+++ b/MMOCoreORB/bin/scripts/mobile/lair/creature_lair/serverobjects.lua
@@ -613,4 +613,4 @@ includeFile("lair/creature_lair/geonosis_spider_droid_brown_neutral.lua")
 includeFile("lair/creature_lair/geonosis_pit_droid_neutral.lua")
 includeFile("lair/creature_lair/geonosis_elite_geonosian_warrior_neutral.lua")
 
-includeFile("lair/creature_lair/mandalore_deathwatch_sbd_lair_neutral.lua")
+includeFile("lair/creature_lair/mandalore_deathwatch_sbd_lair.lua")

--- a/MMOCoreORB/bin/scripts/mobile/mandalore/deathwatch_sbd.lua
+++ b/MMOCoreORB/bin/scripts/mobile/mandalore/deathwatch_sbd.lua
@@ -1,9 +1,9 @@
 deathwatch_sbd = Creature:new {
 	customName = "Deathwatch Super Battle Droid",
-	socialGroup = "death_watch",
+	socialGroup = "",
 	faction = "",
-	level = 200,
-	chanceHit = 18,
+	level = 300,
+	chanceHit = 25,
 	damageMin = 1200,
 	damageMax = 2100,
 	baseXp = 19000,
@@ -26,10 +26,8 @@ deathwatch_sbd = Creature:new {
 	diet = NONE,
 	scale = 1.40,
 
-	templates = {
-		"object/mobile/death_watch_s_battle_droid.iff",
-		"object/mobile/death_watch_s_battle_droid_02.iff",
-		"object/mobile/death_watch_s_battle_droid_03.iff"},
+	templates = {"object/mobile/ep3/ep3_clone_relics_durge_droid_02.iff"},
+		
 	lootGroups = {
 		    {
 			    groups = {
@@ -74,4 +72,4 @@ deathwatch_sbd = Creature:new {
 	defaultAttack = "attack"
 }
 
-CreatureTemplates:addCreatureTemplate(death_watch_s_battle_droid_alt, "death_watch_s_battle_droid_alt")
+CreatureTemplates:addCreatureTemplate(deathwatch_sbd, "deathwatch_sbd")


### PR DESCRIPTION
Fixed bad syntax preventing destroy missions from populating on mission terminal.
Fixed bad syntax causing console errors.
Increased Deathwatch SBD level and tohit chance.