### PR TITLE
Update mandalore_destroy_missions.lua

### DIFF
--- a/MMOCoreORB/bin/scripts/mobile/spawn/destroy_mission/mandalore_destroy_missions.lua
+++ b/MMOCoreORB/bin/scripts/mobile/spawn/destroy_mission/mandalore_destroy_missions.lua
@@ -115,7 +115,7 @@ mandalore_destroy_missions = {
 			minDifficulty = 8,
 			maxDifficulty = 13,
 			size = 25,
-		},-
+		},
 		{
 			lairTemplateName = "global_pirate_camp_neutral_small_theater",
 			minDifficulty = 8,


### PR DESCRIPTION
Fixed bad syntax that was preventing missions from generating on mission terminals.